### PR TITLE
記述ミス修正

### DIFF
--- a/src/asset/sass/object/project/_top.scss
+++ b/src/asset/sass/object/project/_top.scss
@@ -16,10 +16,7 @@
             &:first-child {
                 @include tab-layout {
                     display: flex;
-                    flex-wrap: row nowrap;
                     justify-content: center;
-                    align-items: flex-start;
-                    align-content: flex-start;
                 }
             }
             &--inner:first-child {
@@ -144,10 +141,7 @@
         &__items {
             @include tab-layout {
                 display: flex;
-                flex-wrap: row nowrap;
                 justify-content: center;
-                align-items: flex-start;
-                align-content: flex-start;
                 &--inner:first-child {
                     flex-basis: 70%;
                 }


### PR DESCRIPTION
利用できない値「flex-wrap: row nowrap;」を記述していたため。あわせて記述をシンプルに。